### PR TITLE
Allow setting Rust toolchain as an env var

### DIFF
--- a/docker-helper/docker-cargo-rudra
+++ b/docker-helper/docker-cargo-rudra
@@ -21,8 +21,8 @@ if [[ -z $RUDRA_RUNNER_HOME ]]; then
     exit 1
 fi
 
-if [[ -z $RUSTUP_TOOLCHAIN ]]; then
-    RUSTUP_TOOLCHAIN="nightly-2020-08-26"
+if [[ -z $RUDRA_RUSTUP_TOOLCHAIN ]]; then
+    RUDRA_RUSTUP_TOOLCHAIN="nightly-2020-08-26"
 fi
 
 if [[ -n $2 ]]; then
@@ -36,5 +36,5 @@ docker run -t --rm --user "$(id -u)":"$(id -g)" -v "$RUDRA_RUNNER_HOME":/tmp/rud
     ${DOCKER_ARGS} \
     --env CARGO_HOME=/tmp/rudra-runner-home/cargo_home \
     --env SCCACHE_DIR=/tmp/rudra-runner-home/sccache_home --env SCCACHE_CACHE_SIZE=10T \
-    --env RUSTUP_TOOLCHAIN="$RUSTUP_TOOLCHAIN" \
+    --env RUSTUP_TOOLCHAIN="$RUDRA_RUSTUP_TOOLCHAIN" \
     -v "$(realpath $1)":/tmp/rudra -it -w /tmp/rudra rudra:latest cargo rudra ${CARGO_ARGS}

--- a/docker-helper/docker-cargo-rudra
+++ b/docker-helper/docker-cargo-rudra
@@ -21,6 +21,10 @@ if [[ -z $RUDRA_RUNNER_HOME ]]; then
     exit 1
 fi
 
+if [[ -z $RUSTUP_TOOLCHAIN ]]; then
+    RUSTUP_TOOLCHAIN="nightly-2020-08-26"
+fi
+
 if [[ -n $2 ]]; then
     echo "[*] Creating report directory at $2"
     mkdir $2
@@ -32,5 +36,5 @@ docker run -t --rm --user "$(id -u)":"$(id -g)" -v "$RUDRA_RUNNER_HOME":/tmp/rud
     ${DOCKER_ARGS} \
     --env CARGO_HOME=/tmp/rudra-runner-home/cargo_home \
     --env SCCACHE_DIR=/tmp/rudra-runner-home/sccache_home --env SCCACHE_CACHE_SIZE=10T \
-    --env RUSTUP_TOOLCHAIN=nightly-2020-08-26 \
+    --env RUSTUP_TOOLCHAIN="$RUSTUP_TOOLCHAIN" \
     -v "$(realpath $1)":/tmp/rudra -it -w /tmp/rudra rudra:latest cargo rudra ${CARGO_ARGS}

--- a/docker-helper/rudra-artifact-bash
+++ b/docker-helper/rudra-artifact-bash
@@ -7,8 +7,12 @@ if [[ -z $RUDRA_RUNNER_HOME ]]; then
     exit 1
 fi
 
+if [[ -z $RUSTUP_TOOLCHAIN ]]; then
+    RUSTUP_TOOLCHAIN="nightly-2020-08-26"
+fi
+
 docker run -it --rm --user "$(id -u)":"$(id -g)" -v "$RUDRA_RUNNER_HOME":/tmp/rudra-runner-home \
   --env CARGO_HOME=/tmp/rudra-runner-home/cargo_home \
   --env SCCACHE_DIR=/tmp/rudra-runner-home/sccache_home --env SCCACHE_CACHE_SIZE=10T \
-  --env RUSTUP_TOOLCHAIN=nightly-2020-08-26 \
+  --env RUSTUP_TOOLCHAIN="$RUSTUP_TOOLCHAIN" \
   --env RUDRA_RUNNER_HOME=/tmp/rudra-runner-home rudra-artifact:latest

--- a/docker-helper/rudra-artifact-bash
+++ b/docker-helper/rudra-artifact-bash
@@ -7,12 +7,12 @@ if [[ -z $RUDRA_RUNNER_HOME ]]; then
     exit 1
 fi
 
-if [[ -z $RUSTUP_TOOLCHAIN ]]; then
-    RUSTUP_TOOLCHAIN="nightly-2020-08-26"
+if [[ -z $RUDRA_RUSTUP_TOOLCHAIN ]]; then
+    RUDRA_RUSTUP_TOOLCHAIN="nightly-2020-08-26"
 fi
 
 docker run -it --rm --user "$(id -u)":"$(id -g)" -v "$RUDRA_RUNNER_HOME":/tmp/rudra-runner-home \
   --env CARGO_HOME=/tmp/rudra-runner-home/cargo_home \
   --env SCCACHE_DIR=/tmp/rudra-runner-home/sccache_home --env SCCACHE_CACHE_SIZE=10T \
-  --env RUSTUP_TOOLCHAIN="$RUSTUP_TOOLCHAIN" \
+  --env RUSTUP_TOOLCHAIN="$RUDRA_RUSTUP_TOOLCHAIN" \
   --env RUDRA_RUNNER_HOME=/tmp/rudra-runner-home rudra-artifact:latest


### PR DESCRIPTION
This is a really cool project! We're trying to use Rudra with the `nightly-2021-08-20` toolchain but there's a small issue — if a user pulls the `ghcr.io/sslab-gatech/rudra:2021-08-20` image as specified in the readme and tags it with `rudra:latest`, running the `docker-cargo-rudra` script will give an error that the installed Rust toolchain does not match the `RUSTUP_TOOLCHAIN` env var. I think this PR should resolve that issue so that a user can set `RUDRA_RUSTUP_TOOLCHAIN` to override the variable passed to Docker.