### PR TITLE
Added GitHub Actions support

### DIFF
--- a/.github/action.Dockerfile
+++ b/.github/action.Dockerfile
@@ -3,5 +3,5 @@
 # users to rebuild the container every time its run
 FROM ghcr.io/sslab-gatech/rudra:master
 
-ENTRYPOINT ["rudra"]
+ENTRYPOINT ["cargo", "rudra"]
 

--- a/.github/action.Dockerfile
+++ b/.github/action.Dockerfile
@@ -1,0 +1,7 @@
+# Pulling latest release from GitHub Packages
+# Not using the default Dockerfile because that will cause
+# users to rebuild the container every time its run
+FROM ghcr.io/sslab-gatech/rudra:master
+
+ENTRYPOINT ["rudra"]
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ docker-cargo-rudra <directory>
 
 The log and report are printed to stderr by default.
 
+### Run Rudra as GitHub Action
+
+Rudra can be run as a GitHub Action allowing the static analyze to be used in an Action workflow.
+
+```yml
+# Run Rudra
+- name: Rudra
+  uses: sslab-gatech/Rudra@master
+```
+
 ### Run Rudra with different compiler version
 
 Rudra is tied to a specific Rust compiler version,

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,14 @@
+name: 'Rudra'
+description: 'Rudra is a static analyzer to detect common undefined behaviors in Rust programs'
+
+inputs:
+  directory:
+    description: 'Scan Directory'
+    default: '.'
+
+runs:
+  using: 'docker'
+  image: '.github/action.Dockerfile'
+  args:
+    - ${{ inputs.directory }}
+

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,6 @@ inputs:
 runs:
   using: 'docker'
   image: '.github/action.Dockerfile'
-  args:
-    - ${{ inputs.directory }}
+  # args:
+    # - ${{ inputs.directory }}
 


### PR DESCRIPTION
I have added GitHub Actions support for Rudra so this should make is easier to users to just run in their workflow.

One thing to note is that I created a second `Dockerfile` which just pulls the latest version from GitHub Packages. This is because GitHub Actions will build the container versus pulling an image. Also it helped setting the Entrypoint for the image.

The second thing is that I have left the inputs but they are not used. I wanted to add support for the Action to error out if Rudra found anything but that can be added to inputs as a flag or enabled by default in Actions.

It would also be great to see the Action on the Actions Marketplace in the near future.