### PR TITLE
Rustup to "rustc 1.58.0-nightly (efd048394 2021-10-20)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rudra"
 version = "0.1.0"
 authors = ["Yechan Bae <yechan@gatech.edu>"]
 default-run = "rudra"
-edition = "2018"
+edition = "2021"
 exclude = ["samples"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/DEV.md
+++ b/DEV.md
@@ -97,6 +97,7 @@ cargo rudra  # for crate compilation
 ### Setup rust-analyzer
 
 Run:
+
 ```
 cd ..
 git clone https://github.com/rust-lang/rust.git rust-nightly-2021-10-21
@@ -108,6 +109,7 @@ git submodule update
 ```
 
 Then, add this to the workspace setting (`.vscode/settings.json`):
+
 ```
 {
     "rust-analyzer.rustc.source": "<your path to rust-nightly-2021-10-21>/Cargo.toml"
@@ -115,12 +117,16 @@ Then, add this to the workspace setting (`.vscode/settings.json`):
 ```
 
 If you have any issues with `rust-analyzer` and proc-macros:
+
 1. After running the above code, still in the `rust-nightly-2021-10-21` directory, run:
+
 ```
 cd src/tools/rust-analyzer
 cargo build --release
 ```
+
 2. Add this to the workspace setting (`.vscode/settings.json`):
+
 ```
 {
    "rust-analyzer.server.path": "<your path to rust-nightly-2021-10-21>/src/tools/rust-analyzer/target/release/rust-analyzer"

--- a/DEV.md
+++ b/DEV.md
@@ -4,17 +4,17 @@
 
 ### First-time setup
 
-You need a specific version of nightly Rust (nightly-2021-08-20) for Rudra development.
+You need a specific version of nightly Rust (nightly-2021-10-21) for Rudra development.
 
 ```
 # Toolchain setup
-rustup install nightly-2021-08-20
-rustup default nightly-2021-08-20
+rustup install nightly-2021-10-21
+rustup default nightly-2021-10-21
 rustup component add rustc-dev
 rustup component add miri
 
 # Environment variable setup, put these in your `.bashrc`
-export RUDRA_RUST_CHANNEL=nightly-2021-08-20
+export RUDRA_RUST_CHANNEL=nightly-2021-10-21
 export RUDRA_RUNNER_HOME="<your runner home path - use setup_rudra_runner_home.py>"
 
 export RUSTFLAGS="-L $HOME/.rustup/toolchains/${RUDRA_RUST_CHANNEL}-x86_64-unknown-linux-gnu/lib"
@@ -99,10 +99,10 @@ cargo rudra  # for crate compilation
 Run:
 ```
 cd ..
-git clone https://github.com/rust-lang/rust.git rust-nightly-2021-08-20
-cd rust-nightly-2021-08-20
+git clone https://github.com/rust-lang/rust.git rust-nightly-2021-10-21
+cd rust-nightly-2021-10-21
 # Can be found with rustc --version
-git checkout 6d64f7f69
+git checkout efd048394
 git submodule init
 git submodule update
 ```
@@ -110,6 +110,19 @@ git submodule update
 Then, add this to the workspace setting (`.vscode/settings.json`):
 ```
 {
-    "rust-analyzer.rustcSource": "<your path to rust-nightly-2021-08-20>/Cargo.toml"
+    "rust-analyzer.rustc.source": "<your path to rust-nightly-2021-10-21>/Cargo.toml"
+}
+```
+
+If you have any issues with `rust-analyzer` and proc-macros:
+1. After running the above code, still in the `rust-nightly-2021-10-21` directory, run:
+```
+cd src/tools/rust-analyzer
+cargo build --release
+```
+2. Add this to the workspace setting (`.vscode/settings.json`):
+```
+{
+   "rust-analyzer.server.path": "<your path to rust-nightly-2021-10-21>/src/tools/rust-analyzer/target/release/rust-analyzer"
 }
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM buildpack-deps:buster
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly-2021-08-20 \
+    RUST_VERSION=nightly-2021-10-21 \
     SCCACHE_VERSION=v0.2.15
 
 ENV RUSTFLAGS="-L ${RUSTUP_HOME}/toolchains/${RUST_VERSION}-x86_64-unknown-linux-gnu/lib" \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Rudra can be run as a GitHub Action allowing the static analyze to be used in an
 
 Rudra is tied to a specific Rust compiler version,
 and it can only analyze projects that compiles with this version of the compiler.
-`master` branch uses `nightly-2021-08-20` version of Rust right now.
+`master` branch uses `nightly-2021-10-21` version of Rust right now.
 Check [the version page][version] for all supported versions.
 
 [version]: https://github.com/sslab-gatech/Rudra/pkgs/container/rudra/versions?filters%5Bversion_type%5D=tagged
@@ -60,7 +60,6 @@ Check [the version page][version] for all supported versions.
 - Rudra does not support workspaces (#11).
   You can install Rudra on your host system (see [DEV.md](./DEV.md))
   and run analysis in the subdirectories to sidestep the problem for now.
-- Rudra does not support edition 2021 yet (#19).
 - Rudra does not support suppressing warnings in specific locations.
   This could cause a usability issue when used in CI/CD due to false positives.
 

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -1,3 +1,3 @@
-export RUDRA_RUST_CHANNEL=nightly-2021-08-20
+export RUDRA_RUST_CHANNEL=nightly-2021-10-21
 export RUSTFLAGS="-L $HOME/.rustup/toolchains/${RUDRA_RUST_CHANNEL}-x86_64-unknown-linux-gnu/lib"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$HOME/.rustup/toolchains/${RUDRA_RUST_CHANNEL}-x86_64-unknown-linux-gnu/lib"

--- a/ci/setup_toolchains.sh
+++ b/ci/setup_toolchains.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-rustup install nightly-2021-08-20
-rustup default nightly-2021-08-20
+rustup install nightly-2021-10-21
+rustup default nightly-2021-10-21
 rustup component add rustc-dev
 rustup component add miri

--- a/crawl/Cargo.toml
+++ b/crawl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crawl"
 version = "0.1.0"
 authors = ["Yechan Bae <yechan@gatech.edu>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crawl/src/bin/rudra-runner.rs
+++ b/crawl/src/bin/rudra-runner.rs
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
                 "cargo rudra -Zno-index-update --locked -j 1",
                 &path,
                 &[
-                    ("RUSTUP_TOOLCHAIN", OsStr::new("nightly-2021-08-20")),
+                    ("RUSTUP_TOOLCHAIN", OsStr::new("nightly-2021-10-21")),
                     ("CARGO_HOME", rudra_home_dir.cargo_home_dir().as_ref()),
                     ("SCCACHE_DIR", rudra_home_dir.sccache_home_dir().as_ref()),
                     ("SCCACHE_CACHE_SIZE", "10T".as_ref()),

--- a/docker-helper/docker-cargo-rudra
+++ b/docker-helper/docker-cargo-rudra
@@ -22,7 +22,7 @@ if [[ -z $RUDRA_RUNNER_HOME ]]; then
 fi
 
 if [[ -z $RUDRA_RUSTUP_TOOLCHAIN ]]; then
-    RUDRA_RUSTUP_TOOLCHAIN="nightly-2021-08-20"
+    RUDRA_RUSTUP_TOOLCHAIN="nightly-2021-10-21"
 fi
 
 if [[ -n $2 ]]; then

--- a/docker-helper/rudra-artifact-bash
+++ b/docker-helper/rudra-artifact-bash
@@ -8,7 +8,7 @@ if [[ -z $RUDRA_RUNNER_HOME ]]; then
 fi
 
 if [[ -z $RUDRA_RUSTUP_TOOLCHAIN ]]; then
-    RUDRA_RUSTUP_TOOLCHAIN="nightly-2021-08-20"
+    RUDRA_RUSTUP_TOOLCHAIN="nightly-2021-10-21"
 fi
 
 docker run -it --rm --user "$(id -u)":"$(id -g)" -v "$RUDRA_RUNNER_HOME":/tmp/rudra-runner-home \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Update rudra-runner.rs when updating the compiler version
-channel = "nightly-2021-08-20"
+channel = "nightly-2021-10-21"
 components = ["rustc-dev", "llvm-tools-preview"]

--- a/src/analysis/send_sync_variance/behavior.rs
+++ b/src/analysis/send_sync_variance/behavior.rs
@@ -159,7 +159,7 @@ pub(crate) fn adt_behavior<'tcx>(
                                 // We already know the method takes `self` within its first parameter,
                                 // so we only check whether the first parameter contains a reference.
                                 // e.g. `&self`, `Box<&self>`, `Pin<&self>`, ..
-                                let mut walker = fn_sig.inputs()[0].walk();
+                                let mut walker = fn_sig.inputs()[0].walk(tcx);
                                 while let Some(node) = walker.next() {
                                     if let GenericArgKind::Type(ty) = node.unpack() {
                                         if let ty::TyKind::Ref(_, _, Mutability::Not) = ty.kind() {

--- a/src/analysis/send_sync_variance/mod.rs
+++ b/src/analysis/send_sync_variance/mod.rs
@@ -144,7 +144,6 @@ impl<'tcx> SendSyncVarianceChecker<'tcx> {
 /// Check Send Trait
 fn send_trait_def_id<'tcx>(tcx: TyCtxt<'tcx>) -> AnalysisResult<'tcx, DefId> {
     convert!(tcx
-        // https://github.com/rust-lang/rust/commit/eec856bfbcd79d12352f81b44a9f04e5bb06bda5
         .get_diagnostic_item(sym::Send)
         .context(SendTraitNotFound))
 }

--- a/src/analysis/send_sync_variance/mod.rs
+++ b/src/analysis/send_sync_variance/mod.rs
@@ -144,7 +144,8 @@ impl<'tcx> SendSyncVarianceChecker<'tcx> {
 /// Check Send Trait
 fn send_trait_def_id<'tcx>(tcx: TyCtxt<'tcx>) -> AnalysisResult<'tcx, DefId> {
     convert!(tcx
-        .get_diagnostic_item(sym::send_trait)
+        // https://github.com/rust-lang/rust/commit/eec856bfbcd79d12352f81b44a9f04e5bb06bda5
+        .get_diagnostic_item(sym::Send)
         .context(SendTraitNotFound))
 }
 

--- a/src/analysis/send_sync_variance/phantom.rs
+++ b/src/analysis/send_sync_variance/phantom.rs
@@ -13,13 +13,13 @@ pub fn phantom_indices<'tcx>(tcx: TyCtxt<'tcx>, adt_ty: Ty<'tcx>) -> Vec<u32> {
             for field in &variant.fields {
                 let field_ty = field.ty(tcx, substs);
 
-                let mut walker = field_ty.walk();
+                let mut walker = field_ty.walk(tcx);
                 while let Some(node) = walker.next() {
                     if let GenericArgKind::Type(inner_ty) = node.unpack() {
                         if inner_ty.is_phantom_data() {
                             walker.skip_current_subtree();
 
-                            for x in inner_ty.walk() {
+                            for x in inner_ty.walk(tcx) {
                                 if let GenericArgKind::Type(ph_ty) = x.unpack() {
                                     if let ty::TyKind::Param(ty) = ph_ty.kind() {
                                         in_phantom.insert(ty.index);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate rustc_hir_pretty;
 extern crate rustc_index;
 extern crate rustc_interface;
 extern crate rustc_middle;
-extern crate rustc_mir;
 extern crate rustc_span;
 
 #[macro_use]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -78,7 +78,7 @@ impl<'tcx> TyCtxtExtension<'tcx> {
 
     // rustc's `LateContext::get_def_path`
     // This code is compiler version dependent, so it needs to be updated when we upgrade a compiler.
-    // The current version is based on nightly-2021-08-20
+    // The current version is based on nightly-2021-10-21
     pub fn get_def_path(&self, def_id: DefId) -> Vec<Symbol> {
         use rustc_hir::definitions::{DefPathData, DisambiguatedDefPathData};
         use rustc_middle::ty::print::with_no_trimmed_paths;

--- a/src/report.rs
+++ b/src/report.rs
@@ -93,10 +93,11 @@ impl Report {
 
         let source_map = tcx.sess.source_map();
         let source = if span.from_expansion() {
+            rustc_hir_pretty::id_to_string(&hir_map, item_hir_id)
             // User-Friendly report for macro-generated code
-            rustc_hir_pretty::to_string(hir_map.krate(), |state| {
-                state.print_item(hir_map.expect_item(item_hir_id));
-            })
+            // rustc_hir_pretty::to_string(hir_map.krate(), |state| {
+            //     state.print_item(hir_map.expect_item(item_hir_id));
+            // })
         } else {
             source_map
                 .span_to_snippet(span)

--- a/src/report.rs
+++ b/src/report.rs
@@ -93,11 +93,8 @@ impl Report {
 
         let source_map = tcx.sess.source_map();
         let source = if span.from_expansion() {
-            rustc_hir_pretty::id_to_string(&hir_map, item_hir_id)
             // User-Friendly report for macro-generated code
-            // rustc_hir_pretty::to_string(hir_map.krate(), |state| {
-            //     state.print_item(hir_map.expect_item(item_hir_id));
-            // })
+            rustc_hir_pretty::id_to_string(&hir_map, item_hir_id)
         } else {
             source_map
                 .span_to_snippet(span)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 use std::rc::Rc;
 
-use rustc_middle::ty::{Instance, InstanceDef, TyCtxt};
 use rustc_middle::mir::write_mir_pretty;
+use rustc_middle::ty::{Instance, InstanceDef, TyCtxt};
 use rustc_span::{CharPos, Span};
 
 use termcolor::{Buffer, Color, ColorSpec, WriteColor};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::rc::Rc;
 
 use rustc_middle::ty::{Instance, InstanceDef, TyCtxt};
-use rustc_mir::util::write_mir_pretty;
+use rustc_middle::mir::write_mir_pretty;
 use rustc_span::{CharPos, Span};
 
 use termcolor::{Buffer, Color, ColorSpec, WriteColor};

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -27,7 +27,7 @@ impl<'tcx> RelatedFnCollector<'tcx> {
             hash_map: RelatedItemMap::default(),
         };
 
-        tcx.hir().krate().visit_all_item_likes(&mut collector);
+        tcx.hir().visit_all_item_likes(&mut collector);
 
         collector.hash_map
     }
@@ -139,7 +139,7 @@ pub type AdtImplMap<'tcx> = FxHashMap<DefId, Vec<(LocalDefId, Ty<'tcx>)>>;
 pub fn create_adt_impl_map<'tcx>(tcx: TyCtxt<'tcx>) -> AdtImplMap<'tcx> {
     let mut map = FxHashMap::default();
 
-    for item in tcx.hir().krate().items() {
+    for item in tcx.hir().items() {
         if let ItemKind::Impl(Impl { self_ty, .. }) = item.kind {
             // `Self` type of the given impl block.
             let impl_self_ty = tcx.type_of(self_ty.hir_id.owner);


### PR DESCRIPTION
Fixes #19 
based on #10 

I was able to find 2 specific nightly commits that caused some of the changes:
- [eec856b](https://github.com/rust-lang/rust/commit/eec856bfbcd79d12352f81b44a9f04e5bb06bda5)
  - this one removed `sym::send_trait` and switched usage to use `sym::Send`
- [db9fea5](https://github.com/rust-lang/rust/commit/db9fea508a6db55075d7851211ea5d4b0485e322)
  - this one eliminated `.krate()` from `hir().krate().visit_all_item_likes()` and `hir().krate().items()`

This update might make it a little easier for the next update... but nightly rust really does change nightly.